### PR TITLE
解决由路由引起的Error: 404问题【位置：Enterprise.Web\Areas\Api\Controllers\WeeklyReortController.cs】

### DIFF
--- a/Enterprise.Web/Areas/Api/Controllers/WeeklyReportController.cs
+++ b/Enterprise.Web/Areas/Api/Controllers/WeeklyReportController.cs
@@ -63,6 +63,7 @@ namespace Enterprise.Web.Areas.Api.Controllers
 			return this.RespondResult();
 		}
 
+		[HttpPost("Api/WeeklyReport/Uncheck")]		
 		public ActionResult Uncheck()
 		{
 			string input = base.Request.Query["id"];
@@ -70,6 +71,7 @@ namespace Enterprise.Web.Areas.Api.Controllers
 			return this.RespondResult();
 		}
 
+		[HttpPost("Api/WeeklyReport/ExportByPersonal")]		
 		public ActionResult ExportByPersonal()
 		{
 			ExportByPersonalArgs args = base.RequestArgs<ExportByPersonalArgs>();
@@ -77,6 +79,7 @@ namespace Enterprise.Web.Areas.Api.Controllers
 			return this.RespondDataResult(fileInfo.Name);
 		}
 
+		[HttpPost("Api/WeeklyReport/ExportByWorkType")]		
 		public ActionResult ExportByWorkType()
 		{
 			ExportByWorkTypeArgs exportByWorkTypeArgs = base.RequestArgs<ExportByWorkTypeArgs>();
@@ -85,6 +88,7 @@ namespace Enterprise.Web.Areas.Api.Controllers
 			return this.RespondDataResult(fileInfo.Name);
 		}
 
+		[HttpPost("Api/WeeklyReport/ExportByOrganization")]				
 		public ActionResult ExportByOrganization()
 		{
 			ExportByOrganizationArgs exportByOrganizationArgs = base.RequestArgs<ExportByOrganizationArgs>();


### PR DESCRIPTION
如下问题均是由路由引起的：
1. 点击“查询”里面的“下载”会出错Error: 404，按个人，按组织和按项目都会出错；
2. 设置了考核关系，且被考核人提交了周报后，考核人点击了“已阅”后，再点击“撤销”的时候将报错“Error: 404”。

通过修改文件Enterprise.Web\Areas\Api\Controllers\WeeklyReortController.cs解决了上述提到的“Error:404”错误。
